### PR TITLE
Backend: fix warning with static not applicable to constants

### DIFF
--- a/src/panel-desktop-data.vala
+++ b/src/panel-desktop-data.vala
@@ -204,12 +204,12 @@ public class PanelDesktopData {
         return new JSCore.Value.undefined (ctx);
     }
 
-    static const JSCore.StaticFunction[] js_funcs = {
+    const JSCore.StaticFunction[] js_funcs = {
         { "removeFromDesktop", js_remove_from_desktop, PropertyAttribute.ReadOnly },
         { null, null, 0 }
     };
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "DesktopData",

--- a/src/panel-places.vala
+++ b/src/panel-places.vala
@@ -212,7 +212,7 @@ public class PanelPlaces {
     }
 
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "Places",

--- a/src/panel-session-manager.vala
+++ b/src/panel-session-manager.vala
@@ -210,7 +210,7 @@ public class PanelSessionManager {
     }
 
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "SessionManager",

--- a/src/panel-user.vala
+++ b/src/panel-user.vala
@@ -156,7 +156,7 @@ public class PanelUser {
         return new JSCore.Value.undefined (ctx);
     }
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "UserAccount",

--- a/src/utils.vala
+++ b/src/utils.vala
@@ -254,7 +254,7 @@ namespace Utils {
         return result;
     }
 
-    static const JSCore.StaticFunction[] js_funcs = {
+    const JSCore.StaticFunction[] js_funcs = {
         { "run_desktop", js_run_desktop, PropertyAttribute.ReadOnly },
         { "open_uri", js_open_uri, PropertyAttribute.ReadOnly },
         { "run_command", js_run_command, PropertyAttribute.ReadOnly },
@@ -266,7 +266,7 @@ namespace Utils {
     };
 
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "Utils",

--- a/src/xdg-data.vala
+++ b/src/xdg-data.vala
@@ -303,12 +303,12 @@ public class PanelXdgData {
         return new JSCore.Value.undefined (ctx);
     }
 
-    static const JSCore.StaticFunction[] js_funcs = {
+    const JSCore.StaticFunction[] js_funcs = {
         { "put_to_desktop", js_put_to_desktop, PropertyAttribute.ReadOnly },
         { null, null, 0 }
     };
 
-    static const ClassDefinition js_class = {
+    const ClassDefinition js_class = {
         0,
         ClassAttribute.None,
         "XdgDataBackEnd",


### PR DESCRIPTION
Vala: 0.36.4
GCC: 7.2.1
OS: Fedora 26 x86_64

Vala warns about this construct:
```sh
warning: the modifier `static' is not applicable to constants
```
Full log: https://pastebin.com/raw/Gz1gMW8E
