### PR TITLE
panel-clock: replace Gtk.render_layout with StyleContext.render_layout

### DIFF
--- a/src/panel-clock.vala
+++ b/src/panel-clock.vala
@@ -33,7 +33,7 @@ public class PanelClock : Label {
 	public override bool draw (Cairo.Context cr) {
         StyleContext style = get_style_context ();
         style.set_state (get_state_flags ());
-        Gtk.render_layout (style, cr, MARGIN/2, 0, pango);
+        style.render_layout (cr, MARGIN/2, 0, pango);
         return true;
     }
 	


### PR DESCRIPTION
Fix warning because Gtk.render_layout has been deprecated since vala-0.16