### PR TITLE
Docker-xephyr hack.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -29,6 +29,8 @@ You can do the following:
 - export DISPLAY to whatever your nested X server display number is
 - Run manokwari as usual
 
+It is also possible to run Manokwari inside Docker. See `/scripts/deploy.sh`.
+
 ### Run without GNOME session
 With this you will lose GNOME session capabilities, eg. you can't logout, shutdown, testing different screen sizes, etc.
 But you can quickly run Manokwari in this way.

--- a/scripts/compile-run.sh
+++ b/scripts/compile-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Supposed to run inside a Docker container
+adduser --disabled-password --gecos "" test
+(cd /manokwari && make && make install)
+sudo -H -u test /usr/bin/manokwari

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#./autogen.sh
+#./configure
+#docker pull herpiko/uluwatu-dev
+
+Xephyr :2 -resizeable -fullscreen -ac -softCursor -zap&
+docker run --rm --env DISPLAY=":2" -v $(pwd):/manokwari -v /tmp:/tmp -ti herpiko/uluwatu-dev /bin/bash -c /manokwari/scripts/compile-run.sh

--- a/scripts/dev_require.sh
+++ b/scripts/dev_require.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo apt-get update
+sudo apt-get install gnome-common libglib2.0-dev gtk+-3.0-dev libunique-3.0-dev libwnck-3-dev libgee-dev libgnome-menu-3-dev valac libnotify-dev


### PR DESCRIPTION
Easy way to redeploy manokwari inside an insolated environment.