### PR TITLE
session: add network-managet-applet and gnome-screensaver to manokwari autostart

### DIFF
--- a/files/meson.build
+++ b/files/meson.build
@@ -1,4 +1,5 @@
 subdir('bin')
 subdir('menus')
 subdir('sessions')
+subdir('xdg-autostart')
 subdir('xsessions')

--- a/files/xdg-autostart/manokwari-nm-applet.desktop
+++ b/files/xdg-autostart/manokwari-nm-applet.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Name=Network (Manokwari Desktop)
+Comment=Manage your network connections
+Icon=nm-device-wireless
+Exec=nm-applet
+TryExec=nm-applet
+Terminal=false
+Type=Application
+NoDisplay=true
+OnlyShowIn=Manokwari;
+X-GNOME-Bugzilla-Bugzilla=GNOME
+X-GNOME-Bugzilla-Product=NetworkManager
+X-GNOME-Bugzilla-Component=nm-applet
+X-GNOME-UsesNotifications=true

--- a/files/xdg-autostart/manokwari-screensaver.desktop
+++ b/files/xdg-autostart/manokwari-screensaver.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Name=Screensaver (Manokwari Desktop)
+Comment=Launch screensaver and locker program
+Icon=preferences-desktop-screensaver
+Exec=gnome-screensaver
+TryExec=gnome-screensaver
+OnlyShowIn=Manokwari;
+NoDisplay=true
+X-GNOME-Autostart-Phase=Application
+X-GNOME-Autostart-Notify=true
+X-GNOME-Bugzilla-Bugzilla=GNOME
+X-GNOME-Bugzilla-Product=gnome-screensaver
+X-GNOME-Bugzilla-Component=general

--- a/files/xdg-autostart/meson.build
+++ b/files/xdg-autostart/meson.build
@@ -1,0 +1,9 @@
+manokwari_xdg_autostart = [
+    'manokwari-nm-applet.desktop',
+    'manokwari-screensaver.desktop',
+]
+
+install_data(
+    manokwari_xdg_autostart,
+    install_dir: join_paths('/etc', 'xdg', 'autostart')
+)


### PR DESCRIPTION
Dibanding melakukannya di level distro, hal-hal yang berkaitan dengan suatu DE akan lebih baik jika dikelola oleh DE itu sendiri, misal manokwari membutuhkan network-manager-applet dan cbattion pada panelnya, atau gnome-screensaver yang dibutuhkan sebagai screen locker, dll. Agar semua dependensinya otomatis berjalan saat masuk sesi manokwari, maka dibutuhkan berkas autostart yang spesifik hanya berlaku untuk manokwari saja. Dengan begitu, manokwari menjadi lebih distro-agnostic.

NOTE: Please add other mankowari session dependencies, like cbatticon
and others. You can look at `files/xdg-autostart/*.desktop` files as examples.